### PR TITLE
fixed Configuration API path for v1.1.0

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -14,7 +14,7 @@ set CONNECTION_STRING=StorageType=Directory;RootPath=%cd%\data
 set LOG_DIR=%cd%\logs
 
 rem Start three Configuration API hosts with individual ports and log files
-pushd %INSTALL_DIR%\bin\configurator
+pushd %INSTALL_DIR%\bin\configuration
 FOR /L %%A IN (1,1,3) DO (
   start dotnet Configit.ClmPlatform.Configurator.Host.dll ^
   --Storage:ConnectionString=%CONNECTION_STRING% ^

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ trap "kill 0" EXIT
 # Start three Configuration API hosts with individual ports and log files
 for i in {1..3}
 do
-  pushd "${INSTALL_DIR}/bin/configurator"
+  pushd "${INSTALL_DIR}/bin/configuration"
   dotnet Configit.ClmPlatform.Configurator.Host.dll \
   --Storage:ConnectionString=$CONNECTION_STRING \
   --Kestrel:Endpoints:Http:Url="http://localhost:901${i}" \


### PR DESCRIPTION
The path for the Configuration API seems to have changed (at least it is different in 1.1.0)